### PR TITLE
Conrad crud for User, PlaidItem, User Spending, User Network tables and linear regression.

### DIFF
--- a/server/src/controllers/netWorth.controller.ts
+++ b/server/src/controllers/netWorth.controller.ts
@@ -1,0 +1,104 @@
+import { Request, Response } from "express";
+import { pool } from "../db";
+
+//Get PlaidItems
+export const getAllNetWorths = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query("SELECT * FROM user_net_worth");
+    const nws = result.rows;
+    res.status(200).json(nws);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getNetWorthById = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      "SELECT * FROM user_net_worth WHERE id = $1",
+      [req.params.id]
+    );
+    const nw = result.rows[0];
+    if (!nw) {
+      return res.status(404).json({ message: "User Net Worth not found" });
+    }
+    res.status(200).json(nw);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getNetWorthsByUserId = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      "SELECT * FROM user_net_worth WHERE user_id = $1",
+      [req.params.user_id]
+    );
+    const nw = result.rows[0];
+    if (!nw) {
+      return res.status(404).json({ message: "User Net Worth not found" });
+    }
+    res.status(200).json(nw);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+//Delete Spendings
+export const deleteNetWorth = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      "DELETE FROM user_net_worth WHERE id = $1 RETURNING *",
+      [req.params.id]
+    );
+    const nw = result.rows[0];
+
+    if (!nw) {
+      return res.status(404).json({ message: "User Net Worth not found" });
+    }
+    res.status(200).json({ message: "User Net Worth deleted successfully" });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const deleteNetWorthByUserId = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      "DELETE FROM user_net_worth WHERE user_id = $1 RETURNING *",
+      [req.params.user_id]
+    );
+    const nw = result.rows[0];
+
+    if (!nw) {
+      return res.status(404).json({ message: "User Net Worth not found" });
+    }
+    res.status(200).json({ message: "User Net Worth deleted successfully" });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+//Create Spendings
+export const createNetWorth = async (req: Request, res: Response) => {
+  try {
+    let start_date = req.body.start_date;
+    let end_date = req.body.end_date;
+
+    //Assume spending is money spent from 7 days ago until now
+    if (req.body.start_date === undefined || req.body.end_date === undefined) {
+      end_date = new Date();
+      start_date = new Date(end_date.getTime() - 1000 * 60 * 60 * 24 * 7);
+    }
+
+    const result = await pool.query(
+      "INSERT INTO user_net_worth (start_date, end_date, amount, user_id) VALUES ($1, $2, $3, $4) RETURNING *",
+      [start_date, end_date, req.body.amount, req.body.user_id]
+    );
+    const nw = result.rows[0];
+
+    res.status(201).json(nw);
+  } catch (error: any) {
+    res.status(400).json({ message: error.message });
+  }
+};

--- a/server/src/controllers/plaid.controller.ts
+++ b/server/src/controllers/plaid.controller.ts
@@ -1,22 +1,27 @@
 import { Request, Response } from "express";
-import { Configuration, CountryCode, PlaidApi, PlaidEnvironments, Products } from "plaid";
-
+import {
+  Configuration,
+  CountryCode,
+  PlaidApi,
+  PlaidEnvironments,
+  Products,
+} from "plaid";
 
 const PLAID_CLIENT_ID = process.env.PLAID_CLIENT_ID;
 const PLAID_SECRET = process.env.PLAID_SECRET;
-const PLAID_ENV = process.env.PLAID_ENV || 'sandbox';
+const PLAID_ENV = process.env.PLAID_ENV || "sandbox";
 
 // PLAID_PRODUCTS is a comma-separated list of products to use when initializing
 // Link. Note that this list must contain 'assets' in order for the app to be
 // able to create and retrieve asset reports.
-const PLAID_PRODUCTS = (process.env.PLAID_PRODUCTS || Products.Transactions).split(
-  ',',
-);
+const PLAID_PRODUCTS = (
+  process.env.PLAID_PRODUCTS || Products.Transactions
+).split(",");
 
 // PLAID_COUNTRY_CODES is a comma-separated list of countries for which users
 // will be able to select institutions from.
-const PLAID_COUNTRY_CODES = (process.env.PLAID_COUNTRY_CODES || 'US').split(
-  ',',
+const PLAID_COUNTRY_CODES = (process.env.PLAID_COUNTRY_CODES || "US").split(
+  ","
 );
 
 // Parameters used for the OAuth redirect Link flow.
@@ -26,11 +31,11 @@ const PLAID_COUNTRY_CODES = (process.env.PLAID_COUNTRY_CODES || 'US').split(
 // that the bank website should redirect to. You will need to configure
 // this redirect URI for your client ID through the Plaid developer dashboard
 // at https://dashboard.plaid.com/team/api.
-const PLAID_REDIRECT_URI = process.env.PLAID_REDIRECT_URI || '';
+const PLAID_REDIRECT_URI = process.env.PLAID_REDIRECT_URI || "";
 
 // Parameter used for OAuth in Android. This should be the package name of your app,
 // e.g. com.plaid.linksample
-const PLAID_ANDROID_PACKAGE_NAME = process.env.PLAID_ANDROID_PACKAGE_NAME || '';
+const PLAID_ANDROID_PACKAGE_NAME = process.env.PLAID_ANDROID_PACKAGE_NAME || "";
 
 // We store the access_token in memory - in production, store it in a secure
 // persistent data store
@@ -54,9 +59,9 @@ const configuration = new Configuration({
   basePath: PlaidEnvironments[PLAID_ENV],
   baseOptions: {
     headers: {
-      'PLAID-CLIENT-ID': PLAID_CLIENT_ID,
-      'PLAID-SECRET': PLAID_SECRET,
-      'Plaid-Version': '2020-09-14',
+      "PLAID-CLIENT-ID": PLAID_CLIENT_ID,
+      "PLAID-SECRET": PLAID_SECRET,
+      "Plaid-Version": "2020-09-14",
     },
   },
 });
@@ -73,9 +78,9 @@ export const createLinkToken = async (req: Request, res: Response) => {
         // This should correspond to a unique id for the current user.
         client_user_id: clientUserId,
       },
-      client_name: 'Plaid Test App',
+      client_name: "Plaid Test App",
       products: [Products.Auth],
-      language: 'en',
+      language: "en",
       country_codes: [CountryCode.Us, CountryCode.Ca],
     };
 
@@ -100,7 +105,7 @@ export const exchangePublicToken = async (req: Request, res: Response) => {
     ACCESS_TOKEN = response.data.access_token;
     ITEM_ID = response.data.item_id;
 
-    res.status(200).json({ public_token_exchange: 'complete' });
+    res.status(200).json({ public_token_exchange: "complete" });
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }

--- a/server/src/controllers/plaidItem.controller.ts
+++ b/server/src/controllers/plaidItem.controller.ts
@@ -5,8 +5,8 @@ import { pool } from "../db";
 export const getAllPlaidItems = async (req: Request, res: Response) => {
   try {
     const result = await pool.query("SELECT * FROM plaid_item");
-    const users = result.rows;
-    res.status(200).json(users);
+    const items = result.rows;
+    res.status(200).json(items);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }
@@ -17,11 +17,11 @@ export const getPlaidItemById = async (req: Request, res: Response) => {
     const result = await pool.query("SELECT * FROM plaid_item WHERE id = $1", [
       req.params.id,
     ]);
-    const user = result.rows[0];
-    if (!user) {
+    const item = result.rows[0];
+    if (!item) {
       return res.status(404).json({ message: "Plaid Item not found" });
     }
-    res.status(200).json(user);
+    res.status(200).json(item);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }
@@ -33,11 +33,11 @@ export const getPlaidItemsByUserId = async (req: Request, res: Response) => {
       "SELECT * FROM plaid_item WHERE user_id = $1",
       [req.params.user_id]
     );
-    const user = result.rows[0];
-    if (!user) {
+    const item = result.rows[0];
+    if (!item) {
       return res.status(404).json({ message: "Plaid Items not found" });
     }
-    res.status(200).json(user);
+    res.status(200).json(item);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }
@@ -50,9 +50,9 @@ export const deletePlaidItem = async (req: Request, res: Response) => {
       "DELETE FROM plaid_item WHERE id = $1 RETURNING *",
       [req.params.id]
     );
-    const user = result.rows[0];
+    const item = result.rows[0];
 
-    if (!user) {
+    if (!item) {
       return res.status(404).json({ message: "Plaid Item not found" });
     }
     res.status(200).json({ message: "Plaid Item deleted successfully" });
@@ -67,9 +67,9 @@ export const deletePlaidItemByUserId = async (req: Request, res: Response) => {
       "DELETE FROM plaid_item WHERE user_id = $1 RETURNING *",
       [req.params.user_id]
     );
-    const user = result.rows[0];
+    const item = result.rows[0];
 
-    if (!user) {
+    if (!item) {
       return res.status(404).json({ message: "Plaid Item not found" });
     }
     res.status(200).json({ message: "Plaid Item deleted successfully" });
@@ -81,7 +81,7 @@ export const deletePlaidItemByUserId = async (req: Request, res: Response) => {
 //Create Plaid Item
 export const createPlaidItem = async (req: Request, res: Response) => {
   try {
-    //Check if email already exists
+    //Check if token already exists
     const existingTokens = await pool.query(
       "SELECT COUNT(*) FROM plaid_item WHERE token = $1",
       [req.body.token]
@@ -95,9 +95,9 @@ export const createPlaidItem = async (req: Request, res: Response) => {
       "INSERT INTO plaid_item (token, user_id) VALUES ($1, $2) RETURNING *",
       [req.body.token, req.body.user_id]
     );
-    const user = result.rows[0];
+    const item = result.rows[0];
 
-    res.status(201).json(user);
+    res.status(201).json(item);
   } catch (error: any) {
     res.status(400).json({ message: error.message });
   }

--- a/server/src/controllers/plaidItem.controller.ts
+++ b/server/src/controllers/plaidItem.controller.ts
@@ -81,6 +81,16 @@ export const deletePlaidItemByUserId = async (req: Request, res: Response) => {
 //Create Plaid Item
 export const createPlaidItem = async (req: Request, res: Response) => {
   try {
+    //Check if email already exists
+    const existingTokens = await pool.query(
+      "SELECT COUNT(*) FROM plaid_item WHERE token = $1",
+      [req.body.token]
+    );
+    const nExistingTokens = Number(existingTokens.rows[0].count);
+    if (nExistingTokens > 0) {
+      return res.status(409).json({ message: "Token already registered" });
+    }
+
     const result = await pool.query(
       "INSERT INTO plaid_item (token, user_id) VALUES ($1, $2) RETURNING *",
       [req.body.token, req.body.user_id]

--- a/server/src/controllers/plaidItem.controller.ts
+++ b/server/src/controllers/plaidItem.controller.ts
@@ -1,0 +1,94 @@
+import { Request, Response } from "express";
+import { pool } from "../db";
+
+//Get PlaidItems
+export const getAllPlaidItems = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query("SELECT * FROM plaid_item");
+    const users = result.rows;
+    res.status(200).json(users);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getPlaidItemById = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query("SELECT * FROM plaid_item WHERE id = $1", [
+      req.params.id,
+    ]);
+    const user = result.rows[0];
+    if (!user) {
+      return res.status(404).json({ message: "Plaid Item not found" });
+    }
+    res.status(200).json(user);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getPlaidItemsByUserId = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      "SELECT * FROM plaid_item WHERE user_id = $1",
+      [req.params.user_id]
+    );
+    const user = result.rows[0];
+    if (!user) {
+      return res.status(404).json({ message: "Plaid Items not found" });
+    }
+    res.status(200).json(user);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+//Delete Users
+export const deletePlaidItem = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      "DELETE FROM plaid_item WHERE id = $1 RETURNING *",
+      [req.params.id]
+    );
+    const user = result.rows[0];
+
+    if (!user) {
+      return res.status(404).json({ message: "Plaid Item not found" });
+    }
+    res.status(200).json({ message: "Plaid Item deleted successfully" });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const deletePlaidItemByUserId = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      "DELETE FROM plaid_item WHERE user_id = $1 RETURNING *",
+      [req.params.user_id]
+    );
+    const user = result.rows[0];
+
+    if (!user) {
+      return res.status(404).json({ message: "Plaid Item not found" });
+    }
+    res.status(200).json({ message: "Plaid Item deleted successfully" });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+//Create Users
+export const createPlaidItem = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      "INSERT INTO plaid_item (token, user_id) VALUES ($1, $2) RETURNING *",
+      [req.body.token, req.body.user_id]
+    );
+    const user = result.rows[0];
+
+    res.status(201).json(user);
+  } catch (error: any) {
+    res.status(400).json({ message: error.message });
+  }
+};

--- a/server/src/controllers/plaidItem.controller.ts
+++ b/server/src/controllers/plaidItem.controller.ts
@@ -43,7 +43,7 @@ export const getPlaidItemsByUserId = async (req: Request, res: Response) => {
   }
 };
 
-//Delete Users
+//Delete Plaid Item
 export const deletePlaidItem = async (req: Request, res: Response) => {
   try {
     const result = await pool.query(
@@ -78,7 +78,7 @@ export const deletePlaidItemByUserId = async (req: Request, res: Response) => {
   }
 };
 
-//Create Users
+//Create Plaid Item
 export const createPlaidItem = async (req: Request, res: Response) => {
   try {
     const result = await pool.query(

--- a/server/src/controllers/spendings.controller.ts
+++ b/server/src/controllers/spendings.controller.ts
@@ -106,7 +106,7 @@ export const createSpendings = async (req: Request, res: Response) => {
     let numerator = 0;
     let denominator = 0;
     let accumulate_y = 0;
-    let mu_x = (user_spent["rows"].length + 1) / 2;
+    let mu_x = user_spent["rows"].length / 2;
     let mu_y = 0;
 
     //Determine means
@@ -120,8 +120,8 @@ export const createSpendings = async (req: Request, res: Response) => {
     accumulate_y = 0;
     for (let i = 0; i < user_spent["rows"].length; i++) {
       accumulate_y -= user_spent["rows"][i]["spent_amount"];
-      numerator += (i + 1 - mu_x) * (accumulate_y - mu_y);
-      denominator += (i + 1 - mu_x) * (i + 1 - mu_x);
+      numerator += (i - mu_x) * (accumulate_y - mu_y);
+      denominator += (i - mu_x) * (i - mu_x);
     }
 
     //Get burnRateGoal

--- a/server/src/controllers/spendings.controller.ts
+++ b/server/src/controllers/spendings.controller.ts
@@ -86,7 +86,7 @@ export const createSpendings = async (req: Request, res: Response) => {
     let end_date = req.body.end_date;
 
     //Assume spending is money spent from 7 days ago until now
-    if (req.body.start_date === undefined) {
+    if (req.body.start_date === undefined || req.body.end_date === undefined) {
       end_date = new Date();
       start_date = new Date(end_date.getTime() - 1000 * 60 * 60 * 24 * 7);
     }

--- a/server/src/controllers/spendings.controller.ts
+++ b/server/src/controllers/spendings.controller.ts
@@ -1,0 +1,140 @@
+import { Request, Response } from "express";
+import { pool } from "../db";
+
+//Get PlaidItems
+export const getAllSpendings = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query("SELECT * FROM user_spendings");
+    const users = result.rows;
+    res.status(200).json(users);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getSpendingsById = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      "SELECT * FROM user_spendings WHERE id = $1",
+      [req.params.id]
+    );
+    const user = result.rows[0];
+    if (!user) {
+      return res.status(404).json({ message: "User Spendings not found" });
+    }
+    res.status(200).json(user);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getSpendingsByUserId = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      "SELECT * FROM user_spendings WHERE user_id = $1",
+      [req.params.user_id]
+    );
+    const user = result.rows[0];
+    if (!user) {
+      return res.status(404).json({ message: "User Spendings not found" });
+    }
+    res.status(200).json(user);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+//Delete Spendings
+export const deleteSpendings = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      "DELETE FROM user_spendings WHERE id = $1 RETURNING *",
+      [req.params.id]
+    );
+    const user = result.rows[0];
+
+    if (!user) {
+      return res.status(404).json({ message: "User Spendings not found" });
+    }
+    res.status(200).json({ message: "User Spendings deleted successfully" });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const deleteSpendingsByUserId = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      "DELETE FROM user_spendings WHERE user_id = $1 RETURNING *",
+      [req.params.user_id]
+    );
+    const user = result.rows[0];
+
+    if (!user) {
+      return res.status(404).json({ message: "User Spendings not found" });
+    }
+    res.status(200).json({ message: "User Spendings deleted successfully" });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+//Create Spendings
+export const createSpendings = async (req: Request, res: Response) => {
+  try {
+    let start_date = req.body.start_date;
+    let end_date = req.body.end_date;
+
+    //Assume spending is money spent from 7 days ago until now
+    if (req.body.start_date === undefined) {
+      end_date = new Date();
+      start_date = new Date(end_date.getTime() - 1000 * 60 * 60 * 24 * 7);
+    }
+
+    const result = await pool.query(
+      "INSERT INTO user_spendings (start_date, end_date, spent_amount, user_id) VALUES ($1, $2, $3, $4) RETURNING *",
+      [start_date, end_date, req.body.spent_amount, req.body.user_id]
+    );
+    const user = result.rows[0];
+
+    //Recompute linear regression
+    const user_spent = await pool.query(
+      "SELECT spent_amount FROM user_spendings WHERE user_id = $1",
+      [req.body.user_id]
+    );
+
+    let numerator = 0;
+    let denominator = 0;
+    let accumulate_y = 0;
+    let mu_x = (user_spent["rows"].length + 1) / 2;
+    let mu_y = 0;
+
+    //Determine means
+    for (let i = 0; i < user_spent["rows"].length; i++) {
+      accumulate_y += user_spent["rows"][i]["spent_amount"];
+      mu_y += accumulate_y;
+    }
+    mu_y /= user_spent["rows"].length;
+
+    //OLS
+    accumulate_y = 0;
+    for (let i = 0; i < user_spent["rows"].length; i++) {
+      accumulate_y += user_spent["rows"][i]["spent_amount"];
+      numerator += (i + 1 - mu_x) * (accumulate_y - mu_y);
+      denominator += (i + 1 - mu_x) * (i + 1 - mu_x);
+    }
+
+    let slope = numerator / denominator;
+    let intercept = mu_y - slope * mu_x;
+
+    //Update User's slope and intercept
+    const update_lr = await pool.query(
+      "UPDATE users SET slope = $1, intercept = $2 WHERE id = $3 RETURNING *",
+      [slope, intercept, req.body.user_id]
+    );
+
+    res.status(201).json(user);
+  } catch (error: any) {
+    res.status(400).json({ message: error.message });
+  }
+};

--- a/server/src/controllers/spendings.controller.ts
+++ b/server/src/controllers/spendings.controller.ts
@@ -5,8 +5,8 @@ import { pool } from "../db";
 export const getAllSpendings = async (req: Request, res: Response) => {
   try {
     const result = await pool.query("SELECT * FROM user_spendings");
-    const users = result.rows;
-    res.status(200).json(users);
+    const spent = result.rows;
+    res.status(200).json(spent);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }
@@ -18,11 +18,11 @@ export const getSpendingsById = async (req: Request, res: Response) => {
       "SELECT * FROM user_spendings WHERE id = $1",
       [req.params.id]
     );
-    const user = result.rows[0];
-    if (!user) {
+    const spent = result.rows[0];
+    if (!spent) {
       return res.status(404).json({ message: "User Spendings not found" });
     }
-    res.status(200).json(user);
+    res.status(200).json(spent);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }
@@ -34,11 +34,11 @@ export const getSpendingsByUserId = async (req: Request, res: Response) => {
       "SELECT * FROM user_spendings WHERE user_id = $1",
       [req.params.user_id]
     );
-    const user = result.rows[0];
-    if (!user) {
+    const spent = result.rows[0];
+    if (!spent) {
       return res.status(404).json({ message: "User Spendings not found" });
     }
-    res.status(200).json(user);
+    res.status(200).json(spent);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }
@@ -51,9 +51,9 @@ export const deleteSpendings = async (req: Request, res: Response) => {
       "DELETE FROM user_spendings WHERE id = $1 RETURNING *",
       [req.params.id]
     );
-    const user = result.rows[0];
+    const spent = result.rows[0];
 
-    if (!user) {
+    if (!spent) {
       return res.status(404).json({ message: "User Spendings not found" });
     }
     res.status(200).json({ message: "User Spendings deleted successfully" });
@@ -68,9 +68,9 @@ export const deleteSpendingsByUserId = async (req: Request, res: Response) => {
       "DELETE FROM user_spendings WHERE user_id = $1 RETURNING *",
       [req.params.user_id]
     );
-    const user = result.rows[0];
+    const spent = result.rows[0];
 
-    if (!user) {
+    if (!spent) {
       return res.status(404).json({ message: "User Spendings not found" });
     }
     res.status(200).json({ message: "User Spendings deleted successfully" });
@@ -95,7 +95,7 @@ export const createSpendings = async (req: Request, res: Response) => {
       "INSERT INTO user_spendings (start_date, end_date, spent_amount, user_id) VALUES ($1, $2, $3, $4) RETURNING *",
       [start_date, end_date, req.body.spent_amount, req.body.user_id]
     );
-    const user = result.rows[0];
+    const spent = result.rows[0];
 
     //Recompute linear regression
     const user_spent = await pool.query(
@@ -133,7 +133,7 @@ export const createSpendings = async (req: Request, res: Response) => {
       [slope, intercept, req.body.user_id]
     );
 
-    res.status(201).json(user);
+    res.status(201).json(spent);
   } catch (error: any) {
     res.status(400).json({ message: error.message });
   }

--- a/server/src/controllers/spendings.controller.ts
+++ b/server/src/controllers/spendings.controller.ts
@@ -124,7 +124,7 @@ export const createSpendings = async (req: Request, res: Response) => {
       denominator += (i + 1 - mu_x) * (i + 1 - mu_x);
     }
 
-    let slope = numerator / denominator;
+    let slope = numerator / (denominator + Number.EPSILON);
     let intercept = mu_y - slope * mu_x;
 
     //Update User's slope and intercept

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -58,9 +58,11 @@ export const createUser = async (req: Request, res: Response) => {
       return res.status(409).json({ message: "Email already exists" });
     }
 
+    let dateTime = new Date();
+
     const result = await pool.query(
-      "INSERT INTO users (name, email) VALUES ($1, $2) RETURNING *",
-      [req.body.name, req.body.email]
+      "INSERT INTO users (name, email, burnRateGoal, slope, intercept, date_joined) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *",
+      [req.body.name, req.body.email, req.body.burnRateGoal, 0, 0, dateTime]
     );
     const user = result.rows[0];
 

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -61,7 +61,7 @@ export const createUser = async (req: Request, res: Response) => {
     let dateTime = new Date();
 
     const result = await pool.query(
-      "INSERT INTO users (name, email, burnRateGoal, slope, intercept, date_joined) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *",
+      'INSERT INTO users (name, email, "burnRateGoal", slope, intercept, date_joined) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
       [req.body.name, req.body.email, req.body.burnRateGoal, 0, 0, dateTime]
     );
     const user = result.rows[0];

--- a/server/src/models/netWorth.model.ts
+++ b/server/src/models/netWorth.model.ts
@@ -1,0 +1,7 @@
+export default interface NetWorth {
+  id: number;
+  start_date: Date;
+  end_date: Date;
+  spent_amount: number;
+  user_id: number;
+}

--- a/server/src/models/plaidItem.model.ts
+++ b/server/src/models/plaidItem.model.ts
@@ -1,0 +1,5 @@
+export default interface PlaidItem {
+  id: number;
+  token: string;
+  user_id: number;
+}

--- a/server/src/models/spendings.model.ts
+++ b/server/src/models/spendings.model.ts
@@ -1,9 +1,7 @@
-export default interface User {
+export default interface Spendings {
   id: number;
-  name: string;
-  email: string;
-  budget_by_may: number;
-  date_joined: Date;
-  slope: number;
-  intercept: number;
+  start_date: Date;
+  end_date: Date;
+  spent_amount: number;
+  user_id: number;
 }

--- a/server/src/models/spendings.model.ts
+++ b/server/src/models/spendings.model.ts
@@ -2,7 +2,7 @@ export default interface User {
   id: number;
   name: string;
   email: string;
-  burn_rate_goal: number;
+  budget_by_may: number;
   date_joined: Date;
   slope: number;
   intercept: number;

--- a/server/src/models/user.model.ts
+++ b/server/src/models/user.model.ts
@@ -2,7 +2,7 @@ export default interface User {
   id: number;
   name: string;
   email: string;
-  burn_rate_goal: number;
+  burnRateGoal: number;
   date_joined: Date;
   slope: number;
   intercept: number;

--- a/server/src/routers/netWorth.routes.ts
+++ b/server/src/routers/netWorth.routes.ts
@@ -1,0 +1,21 @@
+import express from "express";
+
+import {
+  getAllNetWorths,
+  getNetWorthById,
+  getNetWorthsByUserId,
+  deleteNetWorth,
+  deleteNetWorthByUserId,
+  createNetWorth,
+} from "../controllers/netWorth.controller";
+
+const netWorthRouter = express.Router();
+
+netWorthRouter.get("/", getAllNetWorths);
+netWorthRouter.get("/:id", getNetWorthById);
+netWorthRouter.get("/user/:user_id", getNetWorthsByUserId);
+netWorthRouter.delete("/:id", deleteNetWorth);
+netWorthRouter.delete("/user/:user_id", deleteNetWorthByUserId);
+netWorthRouter.post("/", createNetWorth);
+
+export default netWorthRouter;

--- a/server/src/routers/plaid.routes.ts
+++ b/server/src/routers/plaid.routes.ts
@@ -1,7 +1,8 @@
 import express from "express";
 
 import {
-    createLinkToken, exchangePublicToken
+  createLinkToken,
+  exchangePublicToken,
 } from "../controllers/plaid.controller";
 
 const plaidRouter = express.Router();

--- a/server/src/routers/plaidItems.routes.ts
+++ b/server/src/routers/plaidItems.routes.ts
@@ -1,0 +1,21 @@
+import express from "express";
+
+import {
+  getAllPlaidItems,
+  getPlaidItemById,
+  getPlaidItemsByUserId,
+  deletePlaidItem,
+  deletePlaidItemByUserId,
+  createPlaidItem,
+} from "../controllers/plaidItem.controller";
+
+const plaidItemRouter = express.Router();
+
+plaidItemRouter.get("/", getAllPlaidItems);
+plaidItemRouter.get("/:id", getPlaidItemById);
+plaidItemRouter.get("/user/:user_id", getPlaidItemsByUserId);
+plaidItemRouter.delete("/:id", deletePlaidItem);
+plaidItemRouter.delete("/user/:user_id", deletePlaidItemByUserId);
+plaidItemRouter.post("/", createPlaidItem);
+
+export default plaidItemRouter;

--- a/server/src/routers/spendings.routes.ts
+++ b/server/src/routers/spendings.routes.ts
@@ -1,14 +1,21 @@
 import express from "express";
 
-import { createSpendings } from "../controllers/spendings.controller";
+import {
+  getAllSpendings,
+  getSpendingsById,
+  getSpendingsByUserId,
+  deleteSpendings,
+  deleteSpendingsByUserId,
+  createSpendings,
+} from "../controllers/spendings.controller";
 
 const spendingsRouter = express.Router();
 
-// spendingsRouter.get("/", getAllExamples);
-// spendingsRouter.get("/:id", getExampleById);
+spendingsRouter.get("/", getAllSpendings);
+spendingsRouter.get("/:id", getSpendingsById);
+spendingsRouter.get("/user/:user_id", getSpendingsByUserId);
+spendingsRouter.delete("/:id", deleteSpendings);
+spendingsRouter.delete("/user/:user_id", deleteSpendingsByUserId);
 spendingsRouter.post("/", createSpendings);
-// spendingsRouter.put("/:id", updateExample);
-
-// spendingsRouter.delete("/:id", deleteExample);
 
 export default spendingsRouter;

--- a/server/src/routers/spendings.routes.ts
+++ b/server/src/routers/spendings.routes.ts
@@ -1,0 +1,14 @@
+import express from "express";
+
+import { createSpendings } from "../controllers/spendings.controller";
+
+const spendingsRouter = express.Router();
+
+// spendingsRouter.get("/", getAllExamples);
+// spendingsRouter.get("/:id", getExampleById);
+spendingsRouter.post("/", createSpendings);
+// spendingsRouter.put("/:id", updateExample);
+
+// spendingsRouter.delete("/:id", deleteExample);
+
+export default spendingsRouter;

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -3,6 +3,8 @@ import userRouter from "./routers/user.routes";
 import exampleRouter from "./routers/example.routes";
 import plaidRouter from "./routers/plaid.routes";
 import spendingsRouter from "./routers/spendings.routes";
+import netWorthRouter from "./routers/netWorth.routes";
+import plaidItemRouter from "./routers/plaidItems.routes";
 const router = express.Router();
 
 // Define your routes here
@@ -10,5 +12,7 @@ router.use("/example", exampleRouter);
 router.use("/plaid", plaidRouter);
 router.use("/user", userRouter);
 router.use("/spendings", spendingsRouter);
+router.use("/plaidItem", plaidItemRouter);
+router.use("/netWorth", netWorthRouter);
 
 export default router;

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -2,12 +2,13 @@ import express from "express";
 import userRouter from "./routers/user.routes";
 import exampleRouter from "./routers/example.routes";
 import plaidRouter from "./routers/plaid.routes";
-
+import spendingsRouter from "./routers/spendings.routes";
 const router = express.Router();
 
 // Define your routes here
 router.use("/example", exampleRouter);
 router.use("/plaid", plaidRouter);
 router.use("/user", userRouter);
+router.use("/spendings", spendingsRouter);
 
 export default router;


### PR DESCRIPTION
Methods for each table:

**user_spendings**
- getAllSpendings
- getSpendingsById
- getSpendingsByUserId
- deleteSpendings
- deleteSpendingsByUserId
- createSpendings

**user_net_worth**
exact same as above (different naming obviously).

**plaid_item**
exact same as above (different naming obviously).

**users**
Same as the current implementation. Only change is body of createUser (since it has more attributes). Slope and intercept are by default 0. date_joined is set to when the POST request was sent.


**Additional Notes:**
For createSpendings, a linear regression line is computed here. Regression line is shifted up by the burn rate goal and with a negative slope. User tables slope and intercept are updated automatically after this call.

For spendings and networth, you can optionally choose to assign a start and end date. If neither is assigned, the end date is assumed as when the POST request was made, and the start date is 7 days before that.

Note that all methods have similar structures (except for users table):
getAll_____  == returns the entire table
get_____ById == get a singular row of the table by it's unique identifier
get_____ByUserId == get one or more rows of the table that which correspond to a particular user ID
delete________  == deletes one row
delete________ByUserId  == deletes all rows associated with a user
create______  == create one row

No need to update any particular entry (as of now).





