### PR TITLE
Ani Fix Lagging Data Bugs

### DIFF
--- a/client/src/pages/BurnPage.tsx
+++ b/client/src/pages/BurnPage.tsx
@@ -36,6 +36,17 @@ const BurnPage: React.FC = () => {
 
   // User-related state variables
   const [loading, setLoading] = useState(true);
+  const [pageData, setPageData] = useState({
+    userBalanceToday: 0,
+    amountSpentThisMonth: 0,
+    userBalanceAtStartOfMonth: 0,
+    monthlyBudget: 0,
+    remainingBudget: 0,
+    linechartData: [],
+    minBalanceData: 0,
+    maxBalanceData: 0,
+    maxDataDifference: 0,
+  });
   const [userBalanceToday, setUserBalanceToday] = useState<number>(0);
   const [userBalanceChangeSinceAugust, setUserBalanceChangeSinceAugust] =
     useState<number>(0);
@@ -68,83 +79,60 @@ const BurnPage: React.FC = () => {
   const projectedUserSpendingPerDay = (user?.slope ?? 0) / 7;
 
   // TODO: clean this up
-  // Helper Functions
-  const processAccountsOverview = (data: AccountsOverview) => {
+  const processAllData = (
+    overviewData: AccountsOverview,
+    balanceData: any,
+    user: any
+  ) => {
     const cashAccountsList =
-      data.depository?.map((account) => ({
-        bankName: account.institution_name, // Correctly using 'institution_name'
+      overviewData.depository?.map((account) => ({
+        bankName: account.institution_name,
         last4CCNumber: account.mask,
         bankNickname: account.name,
         value: account.balances.available,
       })) || [];
 
     const totalUserCash = cashAccountsList.reduce(
-      (sum: number, account: { value: number }) => sum + account.value,
+      (sum, account) => sum + account.value,
       0
     );
-    setUserBalanceToday(totalUserCash);
-
     const projectedSavingsInMay =
-      totalUserCash + projectedUserSpendingPerDay * remainingDaysUntilSchoolEnd;
-    setProjectedUserBalanceInMay(projectedSavingsInMay);
-  };
+      totalUserCash + ((user?.slope ?? 0) / 7) * remainingDaysUntilSchoolEnd;
 
-  const calculateAmountSpentThisMonth = (balanceChanges: {
-    [key: string]: number;
-  }) => {
-    const balanceChangeThisMonth = Object.entries(balanceChanges)
+    const transformedBalanceChanges = balanceData.reduce(
+      (acc: any, curr: any) => {
+        const startDateStr = new Date(curr.start_date).toLocaleDateString();
+        acc[startDateStr] = (acc[startDateStr] || 0) + curr.spent_amount;
+        return acc;
+      },
+      {}
+    );
+
+    const balanceChangeThisMonth = Object.entries(transformedBalanceChanges)
       .filter(([date]) => new Date(date) >= startOfMonth)
-      .reduce((acc, [, value]) => acc + value, 0);
-    setAmountSpentThisMonth(balanceChangeThisMonth);
-    console.log("amountSpentThisMonth");
-    console.log(amountSpentThisMonth);
-    console.log("amountSpentThisMonth");
-  };
+      .reduce((acc, [, value]) => acc + (value as number), 0);
 
-  const calculateUserBalanceAtStartOfMonth = () => {
-    const usersBalanceAtStartOfMonth = userBalanceToday - amountSpentThisMonth;
-    setUserBalanceAtStartOfMonth(usersBalanceAtStartOfMonth);
-    console.log("userBalanceAtStartOfMonth");
-    console.log(userBalanceAtStartOfMonth);
-    console.log("userBalanceAtStartOfMonth");
-  };
-
-  const calculateMonthlyAndRemainingBudget = () => {
+    const usersBalanceAtStartOfMonth = totalUserCash - balanceChangeThisMonth;
     const monthlyBudgetAmount =
-      (userBalanceAtStartOfMonth - goalSavings) / monthsFromTodayToMay;
-    setMonthlyBudget(monthlyBudgetAmount);
+      (usersBalanceAtStartOfMonth - (user?.burn_rate_goal ?? 0)) /
+      monthsFromTodayToMay;
+    const remainingBudgetThisMonth =
+      monthlyBudgetAmount - balanceChangeThisMonth;
+    const totalBalanceChange = Object.values(transformedBalanceChanges).reduce(
+      (acc, value) => (acc as number) + (value as number),
+      0
+    );
+    const userBalanceInAugustCalculation =
+      totalUserCash - (totalBalanceChange as number);
 
-    const remainingBudgetThisMonth = monthlyBudgetAmount - amountSpentThisMonth;
-    setRemainingBudget(remainingBudgetThisMonth);
-  };
-
-  const calculateUserBalanceInAndUserBalanceChangeSinceAugust =
-    (balanceChanges: { [key: string]: number }) => {
-      const totalBalanceChange = Object.values(balanceChanges).reduce(
-        (acc, value) => acc + value,
-        0
-      );
-      setUserBalanceChangeSinceAugust(totalBalanceChange);
-
-      const userBalanceInAugustCalculation =
-        userBalanceToday - totalBalanceChange;
-      setUserBalanceInAugust(userBalanceInAugustCalculation);
-    };
-
-  const processUserBalanceDataFromAugustToToday = (balanceChanges: {
-    [key: string]: number;
-  }) => {
-    let runningTotal = userBalanceInAugust;
-    console.log("userbalanceinaugust");
-    console.log(userBalanceInAugust);
-    console.log("userbalanceinaugust");
-    const balanceDataPoints = Object.entries(balanceChanges)
+    let runningTotal = userBalanceInAugustCalculation;
+    const balanceDataPoints = Object.entries(transformedBalanceChanges)
       .sort(
         ([dateA], [dateB]) =>
           new Date(dateA).getTime() - new Date(dateB).getTime()
       )
       .map(([date, change]) => {
-        runningTotal -= change;
+        runningTotal -= change as number;
         return {
           date: new Date(date).toLocaleDateString(),
           value: runningTotal,
@@ -152,27 +140,37 @@ const BurnPage: React.FC = () => {
       });
 
     let userBalanceDataPointsFromAugustToToday = [
-      { date: "8/1/2023", value: userBalanceInAugust },
+      { date: "8/1/2023", value: userBalanceInAugustCalculation },
       ...balanceDataPoints,
+      {
+        date: new Date().toLocaleDateString("en-US"),
+        value: totalUserCash,
+      },
     ];
-    userBalanceDataPointsFromAugustToToday.push({
-      date: new Date(today).toLocaleDateString("en-US"),
-      value: userBalanceToday,
-    });
 
-    setUserBalanceDataFromAugustToToday(userBalanceDataPointsFromAugustToToday);
+    return {
+      totalUserCash,
+      projectedSavingsInMay,
+      transformedBalanceChanges,
+      balanceChangeThisMonth,
+      usersBalanceAtStartOfMonth,
+      monthlyBudgetAmount,
+      remainingBudgetThisMonth,
+      totalBalanceChange,
+      userBalanceInAugustCalculation,
+      userBalanceDataPointsFromAugustToToday,
+    };
   };
 
-  const createLinechartData = (
-    userBalanceDataFromAugustToToday: { date: string; value: number }[],
-    projectedBalanceOnMay1: number,
-    goalSavingsOnMay1: number
+  const prepareLinechartData = (
+    userBalanceDataFromAugustToToday: any,
+    projectedBalanceOnMay1: any,
+    goalSavingsOnMay1: any,
+    schoolEndDate: any
   ) => {
     const today = new Date().toLocaleDateString("en-US");
-
-    const updatedLineChartData: LineChartData[] =
-      userBalanceDataFromAugustToToday.map((data) => {
-        // Check if the data's date is today
+    const updatedLineChartData = userBalanceDataFromAugustToToday.map(
+      (data: any) => {
         const isToday =
           new Date(data.date).toLocaleDateString("en-US") === today;
 
@@ -182,7 +180,9 @@ const BurnPage: React.FC = () => {
           goalUserBalance: isToday ? data.value : null,
           projectedUserBalance: isToday ? data.value : null,
         };
-      });
+      }
+    );
+
     updatedLineChartData.push({
       date: new Date(schoolEndDate).toLocaleDateString("en-US"),
       actualUserBalance: null,
@@ -191,65 +191,98 @@ const BurnPage: React.FC = () => {
     });
 
     const balanceValues = userBalanceDataFromAugustToToday.map(
-      (data) => data.value
+      (data: any) => data.value
     );
     balanceValues.push(projectedBalanceOnMay1, goalSavingsOnMay1);
+    const minBalanceData = Math.min(...balanceValues);
+    const maxBalanceData = Math.max(...balanceValues);
+    const maxDataDifference = maxBalanceData - minBalanceData;
 
-    setMinBalanceData(Math.min(...balanceValues));
-    setMaxBalanceData(Math.max(...balanceValues));
-    setMaxDataDifference(minBalanceData - maxBalanceData);
-
-    setLinechartData(updatedLineChartData);
+    // Return both the line chart data and the min/max balance data for chart scaling
+    return {
+      lineChartData: updatedLineChartData,
+      minBalanceData,
+      maxBalanceData,
+      maxDataDifference,
+    };
   };
 
-  const loadData = useCallback(async () => {
-    const userData = await me();
-    if (!userData || userData.burn_rate_goal === null) {
-      navigate("/burn-rate-goal");
-      return;
-    }
+  const updateAllStates = (processedData: any) => {
+    const {
+      totalUserCash,
+      projectedSavingsInMay,
+      transformedBalanceChanges,
+      balanceChangeThisMonth,
+      usersBalanceAtStartOfMonth,
+      monthlyBudgetAmount,
+      remainingBudgetThisMonth,
+      totalBalanceChange,
+      userBalanceInAugustCalculation,
+      userBalanceDataPointsFromAugustToToday,
+    } = processedData;
 
-    const overviewData = await fetchAccountsOverview(axiosPrivate);
-    console.log("\n\noverviewData\n\n");
-    console.log(overviewData);
-    console.log("\n\noverviewData\n\n");
-    const balanceData = await fetchAccountBalancesOverTime(
-      axiosPrivate,
-      userData.id
-    );
-    console.log("\n\nbalanceData\n\n");
-    console.log(balanceData);
-    console.log("\n\nbalanceData\n\n");
-    // Transform API response to balanceChanges format.
-    const transformedBalanceChanges = balanceData.reduce(
-      (acc: any, curr: any) => {
-        const startDateStr = new Date(curr.start_date).toLocaleDateString();
-        acc[startDateStr] = (acc[startDateStr] || 0) + curr.spent_amount;
-        return acc;
-      },
-      {}
-    );
-    processAccountsOverview(overviewData);
-
-    // setBalanceChanges(balanceData as { [key: string]: number });
+    setUserBalanceToday(totalUserCash);
+    setProjectedUserBalanceInMay(projectedSavingsInMay);
     setBalanceChanges(transformedBalanceChanges);
-    calculateAmountSpentThisMonth(balanceChanges);
-    calculateUserBalanceAtStartOfMonth();
-    calculateMonthlyAndRemainingBudget();
-    calculateUserBalanceInAndUserBalanceChangeSinceAugust(balanceChanges);
-    processUserBalanceDataFromAugustToToday(balanceChanges);
-    createLinechartData(
-      userBalanceDataFromAugustToToday,
-      projectedUserBalanceInMay,
-      goalSavings
+    setAmountSpentThisMonth(balanceChangeThisMonth);
+    setUserBalanceAtStartOfMonth(usersBalanceAtStartOfMonth);
+    setMonthlyBudget(monthlyBudgetAmount);
+    setRemainingBudget(remainingBudgetThisMonth);
+    setUserBalanceChangeSinceAugust(totalBalanceChange);
+    setUserBalanceInAugust(userBalanceInAugustCalculation);
+    setUserBalanceDataFromAugustToToday(userBalanceDataPointsFromAugustToToday);
+
+
+    const {lineChartData, minBalanceData, maxBalanceData, maxDataDifference} = prepareLinechartData(
+      userBalanceDataPointsFromAugustToToday,
+      projectedSavingsInMay,
+      user?.burn_rate_goal ?? 0, schoolEndDate
     );
-  }, [me, navigate, axiosPrivate]);
+    setMinBalanceData(minBalanceData);
+    setMaxBalanceData(maxBalanceData);
+    setMaxDataDifference(maxDataDifference);
+    setLinechartData(lineChartData);
+  };
+
+  // Helper Functions
+  const loadData = async () => {
+    setLoading(true);
+    try {
+      const userData = await me();
+      if (!userData || userData.burn_rate_goal === null) {
+        navigate("/burn-rate-goal");
+        return;
+      }
+
+      const overviewData = await fetchAccountsOverview(axiosPrivate);
+      console.log("\n\noverviewData\n\n");
+      console.log(overviewData);
+      console.log("\n\noverviewData\n\n");
+      const balanceData = await fetchAccountBalancesOverTime(
+        axiosPrivate,
+        userData.id
+      );
+      console.log("\n\nbalanceData\n\n");
+      console.log(balanceData);
+      console.log("\n\nbalanceData\n\n");
+      // Process data
+      const processedData = processAllData(overviewData, balanceData, me); // Assume this function processes all your data and returns an object with all the state you need to update
+
+      // Update all relevant states here at once
+      updateAllStates(processedData);
+    } catch (error) {
+      console.error("error loading data: ", error);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   // useEffect for loading data before page renders
   useEffect(() => {
-    loadData();
-    setLoading(false);
-  }, [linechartData.length]);
+    loadData().finally(() => setLoading(false));
+    // loadData();
+    // setLoading(false);
+  }, []);
 
   if (loading) {
     return (


### PR DESCRIPTION
1. Dashboard Page: had a "bug" where the page would load in with no accounts in the accounts tabs and total values of 0, this would persist for <1s before the user's account data would be loaded in 
2. Burn Page: linechart had a bug where the balance data would load in chunks, causing the linechart to rerender multiple times before it reached a final state, which just looked weird

I modified the useEffects where the API calls were being made so that we wait for all promises to resolve and all FE data transformations to be finished, before actually displaying the page. This means that we show the loading spinner animation for longer while the data is prepared, but when the page loads in all of the data is 100% ready.


https://github.com/shaham-noorani/pencil/assets/100632819/085ed02c-a22a-4229-bfff-bd2de95d4789
https://github.com/shaham-noorani/pencil/assets/100632819/65c793bc-92a9-4fac-9897-cf9bbd0d25f1

