### PR TITLE
changed bg color of cashtabcomponents to black

### DIFF
--- a/client/src/modules/dashboard/CashTabComponent.tsx
+++ b/client/src/modules/dashboard/CashTabComponent.tsx
@@ -31,7 +31,7 @@ const CashTabComponent = ({
   const handleToggle = () => setIsOpen(!isOpen);
 
   return (
-    <VStack align="stretch" spacing={4} pb="10px">
+    <VStack align="stretch" spacing={1} pb="10px">
       <Flex
         justifyContent="space-between"
         p={4}
@@ -62,9 +62,9 @@ const CashTabComponent = ({
         </Flex>
       </Flex>
       <Collapse in={isOpen}>
-        <VStack p={4} spacing={4} align="stretch">
+        <VStack px={1} align="stretch">
           {accounts.map((account, index) => (
-            <Box key={index} p={3} bg="gray.600" borderRadius="md">
+            <Box key={index} p={3} bg="#151515" borderRadius="md">
               <Text color="white">
                 {account.bankNickname} - ${account.value.toLocaleString()}
               </Text>

--- a/client/src/modules/dashboard/CashTabComponent.tsx
+++ b/client/src/modules/dashboard/CashTabComponent.tsx
@@ -31,11 +31,11 @@ const CashTabComponent = ({
   const handleToggle = () => setIsOpen(!isOpen);
 
   return (
-    <VStack align="stretch" spacing={4}>
+    <VStack align="stretch" spacing={4} pb="10px">
       <Flex
         justifyContent="space-between"
         p={4}
-        bg="gray.700"
+        bg="#151515"
         borderRadius="md"
         alignItems="center"
       >
@@ -61,7 +61,7 @@ const CashTabComponent = ({
           />
         </Flex>
       </Flex>
-      <Collapse in={isOpen} animateOpacity>
+      <Collapse in={isOpen}>
         <VStack p={4} spacing={4} align="stretch">
           {accounts.map((account, index) => (
             <Box key={index} p={3} bg="gray.600" borderRadius="md">

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -31,20 +31,18 @@ const DashboardPage = () => {
   const [maxNetWorthDifference, setMaxNetWorthDifference] = useState<number>(0);
   const [netWorthData, setNetWorthData] = useState<NetWorthDataPoint[]>([]);
 
-
   useEffect(() => {
     const loadData = async () => {
       try {
         const user = await me();
         // Attempt to get the Plaid item for the user
         await axiosPrivate.get(`/plaidItem/user/${user.id}`);
-  
+
         // If successful, proceed with fetching account overview and net worth data
         await Promise.all([
           fetchAccountsOverview(),
-          fetchUserNetWorthData(user)
+          fetchUserNetWorthData(user),
         ]);
-  
       } catch (error) {
         console.error("Error fetching users plaid item entry: ", error);
         navigate("/connect-account");
@@ -52,7 +50,7 @@ const DashboardPage = () => {
       }
       setLoading(false);
     };
-  
+
     loadData();
   }, []);
 
@@ -67,7 +65,7 @@ const DashboardPage = () => {
   const fetchUserNetWorthData = async (user: any) => {
     try {
       const { data } = await axiosPrivate.get(
-        `/netWorth/user/last7/${user.id}`,
+        `/netWorth/user/last7/${user.id}`
       );
       processUserNetWorths(data);
     } catch (error) {
@@ -118,7 +116,7 @@ const DashboardPage = () => {
 
     const totalUserCash = cashAccountsList.reduce(
       (sum: number, account: { value: number }) => sum + account.value,
-      0,
+      0
     );
     setTotalCashBalance(totalUserCash);
     setCashAccounts(cashAccountsList);
@@ -159,8 +157,9 @@ const DashboardPage = () => {
       </Box>
       <Box
         className={`dashboard-box-tabs stage${stage}`}
-        width="full"
+        width="98vw"
         pt="20px"
+        pb="100px"
       >
         <CashTabComponent
           accounts={cashAccounts}


### PR DESCRIPTION
More importantly, if you expand one of the tab components, the bottom-most tab component is no longer hidden below the navbar footer.

Old behavior:
https://github.com/shaham-noorani/pencil/assets/100632819/0d95e10d-9ace-4ba3-91b6-efaf432b7e59

New behavior:
https://github.com/shaham-noorani/pencil/assets/100632819/a4a63f02-2b78-492e-9fd2-6348af79d5fd

Old cash tab component bg:
<img width="351" alt="Screenshot 2024-04-01 at 11 35 41 AM" src="https://github.com/shaham-noorani/pencil/assets/100632819/ff464512-e22f-4847-ae24-50c0051979ed">

New cash tab component bg:
<img width="342" alt="Screenshot 2024-04-01 at 11 34 13 AM" src="https://github.com/shaham-noorani/pencil/assets/100632819/0ad03fe0-b651-4ea6-9509-19872ec97096">
